### PR TITLE
Add FilterContactTypeCommand class and ContactTypePredicate class

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterContactTypeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterContactTypeCommand.java
@@ -7,6 +7,10 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.ContactTypePredicate;
 
+/**
+ * Command to filter contacts in the address book based on their contact type.
+ * Supported contact types are "Work" and "Personal".
+ */
 public class FilterContactTypeCommand extends Command {
     public static final String COMMAND_WORD = "filter";
 

--- a/src/main/java/seedu/address/logic/commands/FilterContactTypeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterContactTypeCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.ContactTypePredicate;
+
+public class FilterContactTypeCommand extends Command {
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Filters your contacts based on their ContactType (Work, Personal).\n"
+            + "Parameters: ContactType (must be either \"Work\" or \"Personal\")\n"
+            + "Example: " + COMMAND_WORD + " Work";
+
+    private final ContactTypePredicate predicate;
+
+    public FilterContactTypeCommand(ContactTypePredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        // instanceof handles nulls
+        if (!(other instanceof FilterContactTypeCommand)) {
+            return false;
+        }
+
+        FilterContactTypeCommand otherFilterCommand = (FilterContactTypeCommand) other;
+        return predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/FilterContactTypeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterContactTypeCommand.java
@@ -17,6 +17,11 @@ public class FilterContactTypeCommand extends Command {
 
     private final ContactTypePredicate predicate;
 
+    /**
+     * Constructs a FilterContactTypeCommand with the given predicate.
+     *
+     * @param predicate The predicate used to filter the contacts based on contact type.
+     */
     public FilterContactTypeCommand(ContactTypePredicate predicate) {
         this.predicate = predicate;
     }
@@ -49,5 +54,4 @@ public class FilterContactTypeCommand extends Command {
                 .add("predicate", predicate)
                 .toString();
     }
-
 }

--- a/src/main/java/seedu/address/model/person/ContactTypePredicate.java
+++ b/src/main/java/seedu/address/model/person/ContactTypePredicate.java
@@ -11,10 +11,22 @@ import seedu.address.commons.util.ToStringBuilder;
 public class ContactTypePredicate implements Predicate<Person> {
     private final ContactType contactType;
 
+    /**
+     * Constructs a ContactTypePredicate with the specified contact type.
+     *
+     * @param contactType The contact type to match against when filtering persons.
+     */
     public ContactTypePredicate(ContactType contactType) {
         this.contactType = contactType;
     }
 
+    /**
+     * Evaluates this predicate on the given person.
+     *
+     * @param person The person to evaluate.
+     * @return true if the person's contact type matches the specified contact type;
+     *         false otherwise.
+     */
     @Override
     public boolean test(Person person) {
         // getContactType() to be implemented on next iteration

--- a/src/main/java/seedu/address/model/person/ContactTypePredicate.java
+++ b/src/main/java/seedu/address/model/person/ContactTypePredicate.java
@@ -1,0 +1,50 @@
+package seedu.address.model.person;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code ContactType} matches the specified contact type.
+ */
+public class ContactTypePredicate implements Predicate<Person> {
+    private final ContactType contactType;
+
+    public ContactTypePredicate(ContactType contactType) {
+        this.contactType = contactType;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        // getContactType() to be implemented on next iteration
+        // to add getContactType() method to the Person class and edit Person class fields
+        // return person.getContactType().equals(contactType);
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ContactTypePredicate)) {
+            return false;
+        }
+
+        ContactTypePredicate otherPredicate = (ContactTypePredicate) other;
+        return contactType.equals(otherPredicate.contactType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(contactType);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("contactType", contactType).toString();
+    }
+}


### PR DESCRIPTION
This PR adds the "filter" keyword to filter work and personal contacts as seen from FilterContactTypeCommand class together with the ContactTypePredicate class but it will not hook the FilterContactTypeCommand class into the parser yet.

Closes #58 