### PR TITLE
Update optionality of TelegramHandle field

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -8,6 +8,7 @@ import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramHandle;
 
 
 /**
@@ -45,7 +46,7 @@ public class Messages {
                 .append("; Email: ")
                 .append(person.getEmail().map(Email::toString).orElse("N/A"))
                 .append("; Telegram Handle: ")
-                .append(person.getTelegramHandle())
+                .append(person.getTelegramHandle().map(TelegramHandle::toString).orElse("N/A"))
                 .append("; Module Name: ")
                 .append(person.getModuleName())
                 .append(": Remark: ")

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -25,7 +25,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
             + "Parameters: "
-            + PREFIX_CONTACTTYPE + "CONTACT TYPE"
+            + PREFIX_CONTACTTYPE + "CONTACT TYPE "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_TELEHANDLE + "TELEGRAMHANDLE] "
             + PREFIX_MOD + "MODULE NAME "
@@ -34,20 +34,19 @@ public class AddCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_CONTACTTYPE + "work"
+            + PREFIX_CONTACTTYPE + "work "
             + PREFIX_NAME + "John Doe "
             + PREFIX_TELEHANDLE + "@johndoe "
-            + PREFIX_MOD + "CS1101S"
+            + PREFIX_MOD + "CS1101S "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_REMARK + "likes to eat chocolate"
+            + PREFIX_REMARK + "likes to eat chocolate "
             + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "owesMoney \n"
+            + "Note: At least one field out of phone, email and telegram handle must be provided";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
-    public static final String MESSAGE_NO_CONTACT_DETAIL = "At least one field out of phone, email and " +
-            "telegram handle must be provided";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -27,7 +27,7 @@ public class AddCommand extends Command {
             + "Parameters: "
             + PREFIX_CONTACTTYPE + "CONTACT TYPE"
             + PREFIX_NAME + "NAME "
-            + PREFIX_TELEHANDLE + "TELEGRAMHANDLE "
+            + "[" + PREFIX_TELEHANDLE + "TELEGRAMHANDLE] "
             + PREFIX_MOD + "MODULE NAME "
             + PREFIX_REMARK + "REMARK "
             + "[" + PREFIX_PHONE + "PHONE] "
@@ -46,6 +46,8 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_NO_CONTACT_DETAIL = "At least one field out of phone, email and " +
+            "telegram handle must be provided";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -109,8 +109,8 @@ public class EditCommand extends Command {
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Optional<Phone> updatedPhone = editPersonDescriptor.getPhone().or(() -> personToEdit.getPhone());
         Optional<Email> updatedEmail = editPersonDescriptor.getEmail().or(() -> personToEdit.getEmail());
-        TelegramHandle updatedTelegramHandle = editPersonDescriptor.getTelegramHandle()
-                .orElse(personToEdit.getTelegramHandle());
+        Optional<TelegramHandle> updatedTelegramHandle = editPersonDescriptor.getTelegramHandle()
+                .or(() -> personToEdit.getTelegramHandle());
         ModuleName updatedModuleName = editPersonDescriptor.getModuleName().orElse(personToEdit.getModuleName());
         Remark updatedRemark = editPersonDescriptor.getRemark().orElse(personToEdit.getRemark());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -53,7 +53,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         // parse required fields
         ContactType contactType = ParserUtil.parseContactType(argMultimap.getValue(PREFIX_CONTACTTYPE).get());
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        //TelegramHandle telegramHandle = ParserUtil.parseTelegramHandle(argMultimap.getValue(PREFIX_TELEHANDLE).get());
         ModuleName moduleName = ParserUtil.parseModuleName(argMultimap.getValue(PREFIX_MOD).get());
         Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get());
 
@@ -75,7 +74,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         // check for at least one out of phone, email and telegram handle
         if (phone.isEmpty() && email.isEmpty() && telegramHandle.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddCommand.MESSAGE_NO_CONTACT_DETAIL));
+                    AddCommand.MESSAGE_USAGE));
         }
 
         Person person = new Person(contactType, name, phone, email, telegramHandle, moduleName, remark, tagList);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -42,21 +42,22 @@ public class AddCommandParser implements Parser<AddCommand> {
                         PREFIX_TELEHANDLE, PREFIX_MOD, PREFIX_REMARK, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_CONTACTTYPE, PREFIX_NAME, PREFIX_MOD,
-                PREFIX_REMARK, PREFIX_TELEHANDLE)
+                PREFIX_REMARK)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        //parse required fields
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_TELEHANDLE, PREFIX_CONTACTTYPE, PREFIX_MOD, PREFIX_REMARK);
+
+        // parse required fields
         ContactType contactType = ParserUtil.parseContactType(argMultimap.getValue(PREFIX_CONTACTTYPE).get());
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        TelegramHandle telegramHandle = ParserUtil.parseTelegramHandle(argMultimap.getValue(PREFIX_TELEHANDLE).get());
+        //TelegramHandle telegramHandle = ParserUtil.parseTelegramHandle(argMultimap.getValue(PREFIX_TELEHANDLE).get());
         ModuleName moduleName = ParserUtil.parseModuleName(argMultimap.getValue(PREFIX_MOD).get());
         Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get());
 
-        //parse optional fields
+        // parse optional fields
         Optional<Phone> phone = argMultimap.getValue(PREFIX_PHONE).isPresent()
                 ? Optional.of(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()))
                 : Optional.empty();
@@ -65,7 +66,17 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ? Optional.of(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()))
                 : Optional.empty();
 
+        Optional<TelegramHandle> telegramHandle = argMultimap.getValue(PREFIX_TELEHANDLE).isPresent()
+                ? Optional.of(ParserUtil.parseTelegramHandle(argMultimap.getValue(PREFIX_TELEHANDLE).get()))
+                : Optional.empty();
+
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        // check for at least one out of phone, email and telegram handle
+        if (phone.isEmpty() && email.isEmpty() && telegramHandle.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddCommand.MESSAGE_NO_CONTACT_DETAIL));
+        }
 
         Person person = new Person(contactType, name, phone, email, telegramHandle, moduleName, remark, tagList);
         return new AddCommand(person);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,7 +24,7 @@ public class Person {
     private final Optional<Email> email;
 
     // Data fields
-    private final TelegramHandle telegramHandle;
+    private final Optional<TelegramHandle> telegramHandle;
     private final ModuleName moduleName;
     private final Remark remark;
     private final Set<Tag> tags = new HashSet<>();
@@ -33,7 +33,7 @@ public class Person {
      * Every field must be present and not null.
      */
     public Person(ContactType contactType, Name name, Optional<Phone> phone, Optional<Email> email,
-                  TelegramHandle telegramHandle, ModuleName moduleName, Remark remark, Set<Tag> tags) {
+                  Optional<TelegramHandle> telegramHandle, ModuleName moduleName, Remark remark, Set<Tag> tags) {
         requireAllNonNull(contactType, name, phone, email, telegramHandle, moduleName, tags);
         this.contactType = contactType;
         this.name = name;
@@ -62,7 +62,7 @@ public class Person {
         return email;
     }
 
-    public TelegramHandle getTelegramHandle() {
+    public Optional<TelegramHandle> getTelegramHandle() {
         return telegramHandle;
     }
 
@@ -135,7 +135,7 @@ public class Person {
                 .add("name", name)
                 .add("phone", phone.map(Phone::toString).orElse(" "))
                 .add("email", email.map(Email::toString).orElse(" "))
-                .add("telegramHandle", telegramHandle)
+                .add("telegramHandle", telegramHandle.map(TelegramHandle::toString).orElse(" "))
                 .add("moduleName", moduleName)
                 .add("remark", remark)
                 .add("tags", tags)

--- a/src/main/java/seedu/address/model/person/TelegramHandleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TelegramHandleContainsKeywordsPredicate.java
@@ -18,8 +18,9 @@ public class TelegramHandleContainsKeywordsPredicate implements Predicate<Person
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-            .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getTelegramHandle().value, keyword));
+        return person.getTelegramHandle().map(handle -> keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(handle.value, keyword)))
+                        .orElse(false);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,22 +24,22 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new ContactType("WORK"), new Name("Alex Yeoh"), Optional.of(new Phone("87438807")),
-                    Optional.of(new Email("alexyeoh@example.com")), new TelegramHandle("@Alexyeoh"),
+                    Optional.of(new Email("alexyeoh@example.com")), Optional.of(new TelegramHandle("@Alexyeoh")),
                     new ModuleName("CS1101S"), new Remark("likes cats"), getTagSet("friends")),
             new Person(new ContactType("WORK"), new Name("Bernice Yu"), Optional.of(new Phone("99272758")),
-                    Optional.of(new Email("berniceyu@example.com")), new TelegramHandle("@Berner"),
+                    Optional.of(new Email("berniceyu@example.com")), Optional.of(new TelegramHandle("@Berner")),
                     new ModuleName("CS1231S"), new Remark("Head TA"), getTagSet("colleagues", "friends")),
             new Person(new ContactType("WORK"), new Name("Charlotte Oliveiro"), Optional.of(new Phone("93210283")),
-                    Optional.of(new Email("charlotte@example.com")), new TelegramHandle("@Charlotte"),
+                    Optional.of(new Email("charlotte@example.com")), Optional.of(new TelegramHandle("@Charlotte")),
                     new ModuleName("MA1522"), new Remark("doesn't like math"), getTagSet("neighbours")),
             new Person(new ContactType("WORK"), new Name("David Li"), Optional.of(new Phone("91031282")),
-                    Optional.of(new Email("lidavid@example.com")), new TelegramHandle("@David2"),
+                    Optional.of(new Email("lidavid@example.com")), Optional.of(new TelegramHandle("@David2")),
                     new ModuleName("CS2030"), new Remark("lives and breathes cs2030"), getTagSet("family")),
             new Person(new ContactType("WORK"), new Name("Irfan Ibrahim"), Optional.of(new Phone("92492021")),
-                    Optional.of(new Email("irfan@example.com")), new TelegramHandle("@Irfan2"),
+                    Optional.of(new Email("irfan@example.com")), Optional.of(new TelegramHandle("@Irfan2")),
                     new ModuleName("CS2040"), new Remark("algorithm god"), getTagSet("classmates")),
             new Person(new ContactType("WORK"), new Name("Roy Balakrishnan"), Optional.of(new Phone("92624417")),
-                    Optional.of(new Email("royb@example.com")), new TelegramHandle("@RoyBala"),
+                    Optional.of(new Email("royb@example.com")), Optional.of(new TelegramHandle("@RoyBala")),
                     new ModuleName("ES2660"), new Remark("professional yapper"), getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -110,11 +110,6 @@ class JsonAdaptedPerson {
                 ? Optional.empty()
                 : Optional.of(new Email(email));
 
-//        if (telegramHandle == null) {
-//            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-//                    TelegramHandle.class.getSimpleName()));
-//        }
-
         if (telegramHandle != null && !TelegramHandle.isValidTelegramHandle(telegramHandle)) {
             throw new IllegalValueException(TelegramHandle.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -66,7 +66,7 @@ class JsonAdaptedPerson {
         name = source.getName().fullName;
         phone = source.getPhone().map(Phone::toString).orElse(null);
         email = source.getEmail().map(Email::toString).orElse(null);
-        telegramHandle = source.getTelegramHandle().value;
+        telegramHandle = source.getTelegramHandle().map(TelegramHandle::toString).orElse(null);
         contactType = source.getContactType().value.toString();
         moduleName = source.getModuleName().toString();
         remark = source.getRemark().toString();
@@ -110,14 +110,17 @@ class JsonAdaptedPerson {
                 ? Optional.empty()
                 : Optional.of(new Email(email));
 
-        if (telegramHandle == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    TelegramHandle.class.getSimpleName()));
-        }
-        if (!TelegramHandle.isValidTelegramHandle(telegramHandle)) {
+//        if (telegramHandle == null) {
+//            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+//                    TelegramHandle.class.getSimpleName()));
+//        }
+
+        if (telegramHandle != null && !TelegramHandle.isValidTelegramHandle(telegramHandle)) {
             throw new IllegalValueException(TelegramHandle.MESSAGE_CONSTRAINTS);
         }
-        final TelegramHandle modelTelegramHandle = new TelegramHandle(telegramHandle);
+        final Optional<TelegramHandle> modelTelegramHandle = telegramHandle == null || telegramHandle.isEmpty()
+                ? Optional.empty()
+                : Optional.of(new TelegramHandle(telegramHandle));
 
         if (contactType == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -10,6 +10,7 @@ import javafx.scene.layout.Region;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramHandle;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -59,7 +60,7 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().map(Phone::toString).orElse(" "));
         email.setText(person.getEmail().map(Email::toString).orElse(" "));
-        telegramHandle.setText(person.getTelegramHandle().value);
+        telegramHandle.setText(person.getTelegramHandle().map(TelegramHandle::toString).orElse(" "));
         moduleName.setText(person.getModuleName().toString());
         String contactTypeStr = person.getContactType().value.toString().toLowerCase();
         remark.setText(person.getRemark().value);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -170,7 +170,7 @@ public class AddCommandParserTest {
         assertParseFailure(parser, CONTACTTYPE_DESC_BOB + VALID_NAME_BOB + TELEHANDLE_DESC_BOB,
                 expectedMessage);
 
-        // missing telegram handle prefix
+        // missing all 3 of telegram handle, phone and email prefixes
         assertParseFailure(parser, CONTACTTYPE_DESC_BOB + NAME_DESC_BOB + VALID_TELEHANDLE_BOB,
                 expectedMessage);
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -95,7 +95,7 @@ public class PersonTest {
         String expected = Person.class.getCanonicalName() + "{contactType=" + ALICE.getContactType() + ", name="
                 + ALICE.getName() + ", phone=" + ALICE.getPhone().map(Phone::toString).orElse(" ")
                 + ", email=" + ALICE.getEmail().map(Email::toString).orElse(" ")
-                + ", telegramHandle=" + ALICE.getTelegramHandle()
+                + ", telegramHandle=" + ALICE.getTelegramHandle().map(TelegramHandle::toString).orElse(" ")
                 + ", moduleName=" + ALICE.getModuleName()
                 + ", remark=" + ALICE.getRemark()
                 + ", tags=" + ALICE.getTags() + "}";

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -32,7 +32,9 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().map(Phone::toString).orElse("");
     private static final String VALID_EMAIL = BENSON.getEmail().map(Email::toString).orElse("");
-    private static final String VALID_TELEHANDLE = BENSON.getTelegramHandle().toString();
+    private static final String VALID_TELEHANDLE = BENSON.getTelegramHandle().map(TelegramHandle::toString)
+            .orElse("");
+
     private static final String VALID_CONTACTTYPE = BENSON.getContactType().toString();
     private static final String VALID_MODULENAME = BENSON.getModuleName().toString();
     private static final String VALID_REMARK = BENSON.getRemark().toString();
@@ -87,14 +89,6 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_TELEHANDLE, VALID_MODULENAME,
                         VALID_REMARK, VALID_TAGS, VALID_CONTACTTYPE);
         String expectedMessage = TelegramHandle.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_nullTelegramHandle_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                null, VALID_MODULENAME, VALID_REMARK, VALID_TAGS, VALID_CONTACTTYPE);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, TelegramHandle.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -36,7 +36,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setName(person.getName());
         descriptor.setPhone(person.getPhone().isPresent() ? person.getPhone().get() : null);
         descriptor.setEmail(person.getEmail().isPresent() ? person.getEmail().get() : null);
-        descriptor.setTelegramHandle(person.getTelegramHandle());
+        descriptor.setTelegramHandle(person.getTelegramHandle().isPresent() ? person.getTelegramHandle().get() : null);
         descriptor.setContactType(person.getContactType());
         descriptor.setModuleName(person.getModuleName());
         descriptor.setRemark(person.getRemark());

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -32,7 +32,7 @@ public class PersonBuilder {
     private Name name;
     private Optional<Phone> phone;
     private Optional<Email> email;
-    private TelegramHandle telegramHandle;
+    private Optional<TelegramHandle> telegramHandle;
     private ModuleName moduleName;
     private Remark remark;
     private Set<Tag> tags;
@@ -45,7 +45,7 @@ public class PersonBuilder {
         name = new Name(DEFAULT_NAME);
         phone = Optional.of(new Phone(DEFAULT_PHONE));
         email = Optional.of(new Email(DEFAULT_EMAIL));
-        telegramHandle = new TelegramHandle(DEFAULT_TELEHANDLE);
+        telegramHandle = Optional.of(new TelegramHandle(DEFAULT_TELEHANDLE));
         moduleName = new ModuleName(DEFAULT_MODULENAME);
         remark = new Remark(DEFAULT_REMARK);
         tags = new HashSet<>();
@@ -108,7 +108,9 @@ public class PersonBuilder {
      * Sets the {@code TelegramHandle} of the {@code Person} that we are building.
      */
     public PersonBuilder withTelegramHandle(String telegramHandle) {
-        this.telegramHandle = new TelegramHandle(telegramHandle);
+        this.telegramHandle = (telegramHandle == null || telegramHandle.isEmpty())
+                ? Optional.empty()
+                : Optional.of(new TelegramHandle(telegramHandle));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -37,7 +37,8 @@ public class PersonUtil {
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
         person.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE + phone.value + " "));
         person.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL + email.value + " "));
-        sb.append(PREFIX_TELEHANDLE + person.getTelegramHandle().value + " ");
+        person.getTelegramHandle().ifPresent(telegramHandle -> sb.append(PREFIX_TELEHANDLE
+                + telegramHandle.value + " "));
         sb.append(PREFIX_MOD + person.getModuleName().toString() + " ");
         sb.append(PREFIX_REMARK + person.getRemark().toString() + " ");
         person.getTags().stream().forEach(


### PR DESCRIPTION
Closes #125 

Update TelegramHandle field to be optional when adding a new contact. At least one of the three fields between Email, Phone and TelegramHandle must be provided for the add command to be valid.