### PR TITLE
Add import feature

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -24,6 +24,7 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.util.SampleDataUtil;
 import seedu.address.storage.AddressBookStorage;
 import seedu.address.storage.JsonAddressBookStorage;
+import seedu.address.storage.JsonImporter;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
@@ -75,6 +76,7 @@ public class MainApp extends Application {
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
         logger.info("Using data file : " + storage.getAddressBookFilePath());
 
+        JsonImporter.initImporterSystem();
         Optional<ReadOnlyAddressBook> addressBookOptional;
         ReadOnlyAddressBook initialData;
         try {

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,32 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Converts a string into its camel case version
+     * @param input a String with at least one uppercase letter
+     * @return the camel case version of the string
+     */
+    public static String toCamelCase(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+
+        StringBuilder camelCaseString = new StringBuilder();
+        boolean firstCapitalFound = false;
+
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+
+            // Convert the first capital letter to lowercase
+            if (Character.isUpperCase(c) && !firstCapitalFound) {
+                camelCaseString.append(Character.toLowerCase(c));
+                firstCapitalFound = true;
+            } else {
+                camelCaseString.append(c);
+            }
+        }
+
+        return camelCaseString.toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -16,7 +16,7 @@ import seedu.address.storage.exceptions.ImporterException;
 /**
  * Imports all .csv files in a directory to the address book
  */
-public class ImportCommand extends Command{
+public class ImportCommand extends Command {
     public static final String COMMAND_WORD = "import";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports contacts from a .csv file to the address book."
@@ -28,14 +28,9 @@ public class ImportCommand extends Command{
     private final File toImport;
 
     /**
-     * Creates an ImportCommand to import a specified {@Code File}
+     * Creates an ImportCommand to import .csv files from the "Import" folder
      */
-    public ImportCommand(File file) {
-        requireNonNull(file);
-        toImport = file;
-    }
-
-    public ImportCommand(){
+    public ImportCommand() {
         toImport = new File("Import");
         assert toImport.exists();
     }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,86 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.util.List;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.storage.CsvToJsonConverter;
+import seedu.address.storage.JsonImporter;
+import seedu.address.storage.exceptions.ConverterException;
+import seedu.address.storage.exceptions.ImporterException;
+
+/**
+ * Imports all .csv files in a directory to the address book
+ */
+public class ImportCommand extends Command{
+    public static final String COMMAND_WORD = "import";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports contacts from a .csv file to the address book."
+            + "Parameters: ";
+
+    public static final String MESSAGE_SUCCESS = "Imported all contacts from: %1$s";
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "This command has not been implemented yet.";
+
+    private final File toImport;
+
+    /**
+     * Creates an ImportCommand to import a specified {@Code File}
+     */
+    public ImportCommand(File file) {
+        requireNonNull(file);
+        toImport = file;
+    }
+
+    public ImportCommand(){
+        toImport = new File("Import");
+        assert toImport.exists();
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<File> jsonFiles;
+
+        CsvToJsonConverter converter = new CsvToJsonConverter(toImport);
+        try {
+            jsonFiles = converter.convertAllCsvFiles();
+        } catch (ConverterException ce) {
+            throw new CommandException(ce);
+        }
+
+        JsonImporter importer = new JsonImporter(jsonFiles);
+        try {
+            importer.importAllJsonFiles(model);
+        } catch (ImporterException e) {
+            throw new CommandException(e);
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toImport.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ImportCommand)) {
+            return false;
+        }
+
+        ImportCommand otherImportCommand = (ImportCommand) other;
+        return toImport.equals(otherImportCommand.toImport);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("toImport", toImport.getName())
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
@@ -16,4 +16,11 @@ public class CommandException extends Exception {
     public CommandException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Constructs a new {@code CommandException} with the specified detail {@code cause}.
+     */
+    public CommandException(Throwable cause) {
+        super( cause);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
@@ -21,6 +21,6 @@ public class CommandException extends Exception {
      * Constructs a new {@code CommandException} with the specified detail {@code cause}.
      */
     public CommandException(Throwable cause) {
-        super( cause);
+        super(cause);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterContactTypeCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SwitchThemeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case SwitchThemeCommand.COMMAND_WORD:
             return new SwitchThemeCommandParser().parse(arguments);
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommand();
 
 
         default:

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -75,6 +75,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.add(p);
     }
 
+    public void addAllPersons(AddressBook addressBook) {
+        for (Person p: addressBook.persons) {
+            this.addPerson(p);
+        }
+    }
+
     /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the address book.

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -75,6 +75,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.add(p);
     }
 
+    /**
+     * Adds all the people from the provided {@Code addressBook} to this address book.
+     * @param addressBook
+     */
     public void addAllPersons(AddressBook addressBook) {
         for (Person p: addressBook.persons) {
             this.addPerson(p);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -69,6 +69,8 @@ public interface Model {
      */
     void addPerson(Person person);
 
+    void addAllPersons(AddressBook addressBook);
+
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -104,6 +104,10 @@ public class ModelManager implements Model {
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
+    public void addAllPersons(AddressBook addressBook) {
+        this.addressBook.addAllPersons(addressBook);
+    }
+
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,6 +2,10 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -133,5 +137,32 @@ public class Person {
                 .add("tags", tags)
                 .toString();
     }
+
+    /**
+     * Looks inside the person class, and returns a {@Code String[]} containing the simple names of all the fields.
+     * Extracts out the field names from class wrapped within a {@Code Optional} as well.
+     * @return A {@Code String[]} containing the simple names of the fields that comprise a Person
+     */
+    public static String[] getFieldSimpleNames() {
+        Class<Person> clazz = Person.class;
+        return Arrays.stream(clazz.getDeclaredFields())
+                .map(Person::getFieldSimpleName)
+                .toArray(String[]::new);
+    }
+
+    private static String getFieldSimpleName(Field field) {
+        Class<?> fieldType = field.getType();
+
+        if (fieldType.equals(Optional.class)) {
+            Type genericType = field.getGenericType();
+            if (genericType instanceof ParameterizedType) {
+                Type actualType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+                return ((Class<?>) actualType).getSimpleName();
+            }
+        }
+
+        return fieldType.getSimpleName();
+    }
+
 
 }

--- a/src/main/java/seedu/address/storage/CsvToJsonConverter.java
+++ b/src/main/java/seedu/address/storage/CsvToJsonConverter.java
@@ -1,0 +1,103 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
+
+import seedu.address.model.person.Person;
+import seedu.address.storage.exceptions.ConverterException;
+
+/**
+ * A class created to handle all conversion from .csv file to .json file for mass importing of contacts
+ */
+public class CsvToJsonConverter {
+
+    private final String directoryPath;
+    private final File directory;
+    private final String[] personFieldNames;
+
+    /**
+     * creates a new CsvToJsonConverter object with the provided {@Code String directorypath}. Checks if the given
+     * path is a valid directory. Will convert all .csv files inside the directory to .json files.
+     * @param directoryPath the string representation of the path to the directory which stores the .csv files
+     */
+    public CsvToJsonConverter(String directoryPath) {
+        personFieldNames = Person.getFieldSimpleNames();
+        this.directoryPath = directoryPath;
+        this.directory = new File(directoryPath);
+
+        if (!directory.exists() || !this.directory.isDirectory()) {
+            throw new IllegalArgumentException("The provided path is not a directory");
+        }
+    }
+
+    private File[] findAllCsvFiles() throws IOException {
+        File[] csvFiles = directory.listFiles((dir, name) -> name.toLowerCase().endsWith(".csv"));
+
+        if (csvFiles == null || csvFiles.length == 0) {
+            throw new IOException("The provided path contains no .csv files to import");
+        }
+        return csvFiles;
+    }
+
+    private ArrayNode parseCsvFile() throws ConverterException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        BufferedReader br;
+        try {
+            FileReader fr = new FileReader(this.directoryPath);
+            br = new BufferedReader(fr);
+        } catch (FileNotFoundException fnfe) {
+            throw new ConverterException("File not found", fnfe);
+        }
+         try {
+             String line = br.readLine();
+
+             if (line == null) {
+                 throw new IOException(".csv file is empty");
+             }
+
+             String[] headers = line.split(",");
+
+             ArrayNode jsonArray = objectMapper.createArrayNode();
+
+             line = br.readLine();
+             while (line != null) {
+                 String[] values = line.split(",");
+
+                 ObjectNode jsonObject = objectMapper.createObjectNode();
+
+                 for (int i = 0; i < headers.length; i++) {
+                     if (!jsonObject.get(headers[i]).isNull()) {
+                         continue;
+                     } else if (!Arrays.asList(personFieldNames).contains(headers[i])) {
+                         continue;
+                     }
+
+                     if (values[i].isBlank()) {
+                         values[i] = null;
+                     }
+
+                     jsonObject.put(headers[i], values[i]);
+                 }
+
+                 jsonArray.add(jsonObject);
+             }
+             return jsonArray;
+         } catch (IOException ioe) {
+            throw new ConverterException("There has been a corrupted input", ioe);
+         }
+    }
+
+    private static void containsValidHeaders(File csvFile) {
+
+    }
+
+
+}

--- a/src/main/java/seedu/address/storage/CsvToJsonConverter.java
+++ b/src/main/java/seedu/address/storage/CsvToJsonConverter.java
@@ -1,9 +1,5 @@
 package seedu.address.storage;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -12,6 +8,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Person;
@@ -47,11 +47,11 @@ public class CsvToJsonConverter {
      * @return A List containing all the successfully converted .json files
      * @throws ConverterException When the provided path contains no .csv files to convert
      */
-    public List<File> convertAllCsvFiles() throws ConverterException{
+    public List<File> convertAllCsvFiles() throws ConverterException {
         List<File> jsonFiles = new ArrayList<>();
         if (directory.getName().endsWith(".csv")) {
             jsonFiles.add(convertCsvFile(directory));
-        } else if (directory.isDirectory()){
+        } else if (directory.isDirectory()) {
             try {
                 File[] files = findAllCsvFiles();
                 for (File csvFile: files) {
@@ -110,7 +110,7 @@ public class CsvToJsonConverter {
         }
     }
 
-    private BufferedReader createNewBufferedReader(File csvFile) throws ConverterException{
+    private BufferedReader createNewBufferedReader(File csvFile) throws ConverterException {
         try {
             FileReader fr = new FileReader(csvFile);
             return new BufferedReader(fr);
@@ -118,8 +118,7 @@ public class CsvToJsonConverter {
             throw new ConverterException("File not found", fnfe);
         }
     }
-    
-    private String[] getHeaders(BufferedReader br) throws IOException{
+    private String[] getHeaders(BufferedReader br) throws IOException {
         String line = br.readLine();
 
         if (line == null) {

--- a/src/main/java/seedu/address/storage/CsvToJsonConverter.java
+++ b/src/main/java/seedu/address/storage/CsvToJsonConverter.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Person;
 import seedu.address.storage.exceptions.ConverterException;
 
@@ -31,6 +32,9 @@ public class CsvToJsonConverter {
      */
     public CsvToJsonConverter(File directory) {
         personFieldNames = Person.getFieldSimpleNames();
+        for (int i = 0; i < personFieldNames.length; i++) {
+            personFieldNames[i] = StringUtil.toCamelCase(personFieldNames[i]);
+        }
         this.directory = directory;
 
         if (!directory.exists() || !this.directory.isDirectory()) {
@@ -96,8 +100,10 @@ public class CsvToJsonConverter {
     private File writeToJson(ObjectMapper content, ArrayNode arrayNode,
                                 String jsonFilePath) throws ConverterException {
         try {
+            ObjectNode rootObject = content.createObjectNode();
+            rootObject.set("persons", arrayNode);
             File toReturn = new File(jsonFilePath);
-            content.writerWithDefaultPrettyPrinter().writeValue(toReturn, arrayNode);
+            content.writerWithDefaultPrettyPrinter().writeValue(toReturn, rootObject);
             return toReturn;
         } catch (IOException e) {
             throw new ConverterException("Could not write to Json File");
@@ -129,12 +135,14 @@ public class CsvToJsonConverter {
         ObjectNode jsonObject = objectMapper.createObjectNode();
 
         for (int i = 0; i < headers.length; i++) {
-            if (!jsonObject.get(headers[i]).isNull()) {
+            if (jsonObject.has(headers[i]) && !jsonObject.get(headers[i]).isNull()) {
+                System.out.println("this");
                 continue;
             } else if (!Arrays.asList(this.personFieldNames).contains(headers[i])) {
+                System.out.println("that");
                 continue;
             }
-
+            System.out.println(headers[i] + ": " + values[i]);
             if (values[i].isBlank()) {
                 values[i] = null;
             }
@@ -151,7 +159,7 @@ public class CsvToJsonConverter {
         assert csvName.endsWith(".csv");
 
         if (!csvName.isBlank() && csvName.endsWith(".csv")) {
-            return csvName.replace(".csv", ".json");
+            return new File(csvFile.getParent(), csvName.replace(".csv", ".json")).getPath();
         } else {
             throw new IllegalArgumentException("Filename must end with .csv");
         }

--- a/src/main/java/seedu/address/storage/CsvToJsonConverter.java
+++ b/src/main/java/seedu/address/storage/CsvToJsonConverter.java
@@ -19,7 +19,6 @@ import seedu.address.storage.exceptions.ConverterException;
  */
 public class CsvToJsonConverter {
 
-    private final String directoryPath;
     private final File directory;
     private final String[] personFieldNames;
 
@@ -30,7 +29,6 @@ public class CsvToJsonConverter {
      */
     public CsvToJsonConverter(String directoryPath) {
         personFieldNames = Person.getFieldSimpleNames();
-        this.directoryPath = directoryPath;
         this.directory = new File(directoryPath);
 
         if (!directory.exists() || !this.directory.isDirectory()) {
@@ -47,53 +45,91 @@ public class CsvToJsonConverter {
         return csvFiles;
     }
 
-    private ArrayNode parseCsvFile() throws ConverterException {
+    private boolean convertCsvFile(File csvFile) throws ConverterException {
         ObjectMapper objectMapper = new ObjectMapper();
-        BufferedReader br;
+        BufferedReader br = createNewBufferedReader(csvFile);
+        ArrayNode jsonArray = objectMapper.createArrayNode();
         try {
-            FileReader fr = new FileReader(this.directoryPath);
-            br = new BufferedReader(fr);
+            String[] headers = getHeaders(br);
+            addAllJSonObjects(br, objectMapper, headers, jsonArray);
+            br.close();
+        } catch (IOException ioe) {
+            throw new ConverterException("There has been a corrupted input", ioe);
+        }
+        writeToJson(objectMapper, jsonArray, getJsonName(csvFile));
+        return true;
+    }
+
+    private void addAllJSonObjects(BufferedReader br, ObjectMapper objectMapper,
+                                   String[] headers, ArrayNode jsonArray) throws IOException {
+        String line = br.readLine();
+        while (line != null) {
+            ObjectNode jsonObject = addNextJsonObject(line, objectMapper, headers);
+            line = br.readLine();
+            jsonArray.add(jsonObject);
+        }
+    }
+
+    private boolean writeToJson(ObjectMapper content, ArrayNode arrayNode,
+                                String jsonFilePath) throws ConverterException {
+        try {
+            content.writerWithDefaultPrettyPrinter().writeValue(new File(jsonFilePath), arrayNode);
+            return true;
+        } catch (IOException e) {
+            throw new ConverterException("Could not write to Json File");
+        }
+    }
+
+    private BufferedReader createNewBufferedReader(File csvFile) throws ConverterException{
+        try {
+            FileReader fr = new FileReader(csvFile);
+            return new BufferedReader(fr);
         } catch (FileNotFoundException fnfe) {
             throw new ConverterException("File not found", fnfe);
         }
-         try {
-             String line = br.readLine();
+    }
+    
+    private String[] getHeaders(BufferedReader br) throws IOException{
+        String line = br.readLine();
 
-             if (line == null) {
-                 throw new IOException(".csv file is empty");
-             }
+        if (line == null) {
+            throw new IOException(".csv file is empty");
+        }
 
-             String[] headers = line.split(",");
-
-             ArrayNode jsonArray = objectMapper.createArrayNode();
-
-             line = br.readLine();
-             while (line != null) {
-                 String[] values = line.split(",");
-
-                 ObjectNode jsonObject = objectMapper.createObjectNode();
-
-                 for (int i = 0; i < headers.length; i++) {
-                     if (!jsonObject.get(headers[i]).isNull()) {
-                         continue;
-                     } else if (!Arrays.asList(personFieldNames).contains(headers[i])) {
-                         continue;
-                     }
-
-                     if (values[i].isBlank()) {
-                         values[i] = null;
-                     }
-
-                     jsonObject.put(headers[i], values[i]);
-                 }
-
-                 jsonArray.add(jsonObject);
-             }
-             return jsonArray;
-         } catch (IOException ioe) {
-            throw new ConverterException("There has been a corrupted input", ioe);
-         }
+        return line.split(",");
     }
 
+    private ObjectNode addNextJsonObject(String line, ObjectMapper objectMapper, String[] headers) {
+        String[] values = line.split(",");
 
+        ObjectNode jsonObject = objectMapper.createObjectNode();
+
+        for (int i = 0; i < headers.length; i++) {
+            if (!jsonObject.get(headers[i]).isNull()) {
+                continue;
+            } else if (!Arrays.asList(this.personFieldNames).contains(headers[i])) {
+                continue;
+            }
+
+            if (values[i].isBlank()) {
+                values[i] = null;
+            }
+
+            jsonObject.put(headers[i], values[i]);
+        }
+        return jsonObject;
+    }
+
+    private String getJsonName(File csvFile) {
+        assert csvFile != null;
+        String csvName = csvFile.getName();
+
+        assert csvName.endsWith(".csv");
+
+        if (!csvName.isBlank() && csvName.endsWith(".csv")) {
+            return csvName.replace(".csv", ".json");
+        } else {
+            throw new IllegalArgumentException("Filename must end with .csv");
+        }
+    }
 }

--- a/src/main/java/seedu/address/storage/CsvToJsonConverter.java
+++ b/src/main/java/seedu/address/storage/CsvToJsonConverter.java
@@ -95,9 +95,5 @@ public class CsvToJsonConverter {
          }
     }
 
-    private static void containsValidHeaders(File csvFile) {
-
-    }
-
 
 }

--- a/src/main/java/seedu/address/storage/JsonImporter.java
+++ b/src/main/java/seedu/address/storage/JsonImporter.java
@@ -3,27 +3,15 @@ package seedu.address.storage;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.person.Person;
 import seedu.address.storage.exceptions.ImporterException;
 
 /**
@@ -41,7 +29,7 @@ public class JsonImporter {
         this.jsonFiles.addAll(jsonFiles);
     }
 
-    private final Model importJsonFile(File jsonFile, Model model)  throws ImporterException {
+    private Model importJsonFile(File jsonFile, Model model) throws ImporterException {
         requireNonNull(jsonFile);
 
         Path filePath = jsonFile.toPath().toAbsolutePath();
@@ -65,6 +53,12 @@ public class JsonImporter {
         }
     }
 
+    /**
+     * Imports all .json files converted by the CsvToJsonConverter
+     * @param model model which the .json files should be imported to
+     * @return The model after the .json files have been imported
+     * @throws ImporterException if there was any error during the execution of the importer
+     */
     public final Model importAllJsonFiles(Model model) throws ImporterException {
         for (File file: jsonFiles) {
             importJsonFile(file, model);
@@ -72,7 +66,11 @@ public class JsonImporter {
         return model;
     }
 
-    public static final boolean initImporterSystem() throws IllegalStateException{
+    /**
+     * Inits the necessary folders for the import command to work
+     * @throws IllegalStateException if the "Import" file exists but is not a directory
+     */
+    public static final void initImporterSystem() throws IllegalStateException {
 
         File importer = new File("Import");
 
@@ -81,7 +79,6 @@ public class JsonImporter {
         } else if (!importer.isDirectory()) {
             throw new IllegalStateException("'Import' exists but is not a directory.");
         }
-        return true;
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonImporter.java
+++ b/src/main/java/seedu/address/storage/JsonImporter.java
@@ -3,15 +3,10 @@ package seedu.address.storage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-
-import seedu.address.commons.exceptions.DataLoadingException;
-import seedu.address.commons.util.JsonUtil;
-import seedu.address.model.UserPrefs;
 
 /**
  * A class that does all the importing of data from a group of .json files to AddressBook.json

--- a/src/main/java/seedu/address/storage/JsonImporter.java
+++ b/src/main/java/seedu/address/storage/JsonImporter.java
@@ -1,0 +1,87 @@
+package seedu.address.storage;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import seedu.address.commons.exceptions.DataLoadingException;
+import seedu.address.commons.util.JsonUtil;
+import seedu.address.model.UserPrefs;
+
+/**
+ * A class that does all the importing of data from a group of .json files to AddressBook.json
+ */
+public class JsonImporter {
+    private final Path AddressBookFilePath;
+    private final File directoryToImport;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Creates a new instance of JsonImporter which will handle all the importing from the provided directory path
+     * @param directoryPath path to the directory containing all the .json files to be imported
+     */
+    public JsonImporter(String directoryPath, JsonAddressBookStorage storage) {
+        this.directoryToImport = new File(directoryPath);
+        this.AddressBookFilePath = storage.getAddressBookFilePath();
+        if (!directoryToImport.exists() || !this.directoryToImport.isDirectory()) {
+            throw new IllegalArgumentException("The provided path is not a directory");
+        }
+    }
+
+    public static void appendJsonFiles(File targetFile, File sourceDirectory) throws IOException {
+        // Step 1: Directly load the existing AddressBook.json data as an ArrayNode
+        ArrayNode targetArray = loadJsonArrayFromFile(targetFile);
+
+        // Step 2: Get all JSON files in the source directory
+        File[] jsonFiles = sourceDirectory.listFiles((dir, name) -> name.endsWith(".json"));
+        if (jsonFiles == null) {
+            System.out.println("No JSON files found in the specified directory.");
+            return;
+        }
+
+        // Step 3: Append each JSON file's content to the target array
+        for (File jsonFile : jsonFiles) {
+            if (!jsonFile.equals(targetFile)) {  // Avoid appending the target file itself
+                ArrayNode sourceArray = loadJsonFileAsArray(jsonFile);
+                targetArray.addAll(sourceArray);  // Append data from source array
+            }
+        }
+
+        // Step 4: Write the combined array back to the target file
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(targetFile, targetArray);
+        System.out.println("Appended JSON files to " + targetFile.getName());
+    }
+
+    // Helper method to load an existing JSON array from a file
+    private static ArrayNode loadJsonArrayFromFile(File file) throws IOException {
+        if (!file.exists()) {
+            throw new IOException("The file " + file.getName() + " does not exist.");
+        }
+
+        JsonNode jsonNode = objectMapper.readTree(file);
+        if (jsonNode.isArray()) {
+            return (ArrayNode) jsonNode;
+        } else {
+            throw new IOException("Expected JSON array in " + file.getName());
+        }
+    }
+
+    // Helper method to load a JSON file as an ArrayNode; wraps objects in an array if necessary
+    private static ArrayNode loadJsonFileAsArray(File file) throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(file);
+        if (jsonNode.isArray()) {
+            return (ArrayNode) jsonNode;
+        } else if (jsonNode.isObject()) {
+            ArrayNode arrayNode = objectMapper.createArrayNode();
+            arrayNode.add(jsonNode);
+            return arrayNode;
+        } else {
+            throw new IOException("Invalid JSON data in " + file.getName());
+        }
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -57,4 +57,17 @@ class JsonSerializableAddressBook {
         return addressBook;
     }
 
+    /**
+     * Merges two instances of {@Code AddressBook}, adding all instances of {@Code Person} from the source to the
+     * target.
+     * @param target the {@Code AddressBook} that the Persons will be added to
+     * @param source the {@Code AddressBook} that the Persons will be added from
+     * @return the target {@Code AddressBook} after adding the source {@Code AddressBook}
+     */
+    public JsonSerializableAddressBook mergeAddressBook(JsonSerializableAddressBook target,
+                                                        JsonSerializableAddressBook source) {
+        target.persons.addAll(source.persons);
+        return target;
+    }
+
 }

--- a/src/main/java/seedu/address/storage/exceptions/ConverterException.java
+++ b/src/main/java/seedu/address/storage/exceptions/ConverterException.java
@@ -1,0 +1,12 @@
+package seedu.address.storage.exceptions;
+
+public class ConverterException extends Exception{
+
+    public ConverterException(String message) {
+        super(message);
+    }
+
+    public ConverterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/seedu/address/storage/exceptions/ConverterException.java
+++ b/src/main/java/seedu/address/storage/exceptions/ConverterException.java
@@ -1,6 +1,10 @@
 package seedu.address.storage.exceptions;
 
-public class ConverterException extends Exception{
+
+/**
+ * Represents an error which occurs during execution of the {@Code Converter}.
+ */
+public class ConverterException extends Exception {
 
     public ConverterException(String message) {
         super(message);

--- a/src/main/java/seedu/address/storage/exceptions/ImporterException.java
+++ b/src/main/java/seedu/address/storage/exceptions/ImporterException.java
@@ -1,13 +1,12 @@
 package seedu.address.storage.exceptions;
 
-public class ImporterException extends Exception{
+/**
+ * Represents an error which occurs during execution of the {@Code Importer}.
+ */
+public class ImporterException extends Exception {
 
     public ImporterException(String message) {
         super(message);
-    }
-
-    public ImporterException(String message, Throwable cause) {
-        super(message, cause);
     }
 
     public ImporterException(Throwable cause) {

--- a/src/main/java/seedu/address/storage/exceptions/ImporterException.java
+++ b/src/main/java/seedu/address/storage/exceptions/ImporterException.java
@@ -1,0 +1,16 @@
+package seedu.address.storage.exceptions;
+
+public class ImporterException extends Exception{
+
+    public ImporterException(String message) {
+        super(message);
+    }
+
+    public ImporterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ImporterException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -124,6 +124,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addAllPersons(AddressBook addressBook) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
closes #131 

Accomplishes the task by first taking in a .csv file with proper headings, then converting the .csv file to .json files. This is done by the (appropriately named) `CsvToJsonConverter `class. The `convertAllCsvFiles()` function returns a `List<File>` containing .json Files

This List is then passed to the JsonImporter class, which takes the .json files and reads the files using the same method as AB3 when first loading up the data from addressbook.json upon initialising the MainApp. 

The command currently accounts for
1. Missing headers which are inside the `Person` field but not inside the .csv file(adds a null value)
2. Extra headers which are inside the .csv file but not inside the `Person` class (Ignores values)
3. .csv files containing data which do not match the requirements for being added using the `AddCommand` (will not add person's data)

Note that for point 3 currently, if a single data cell is wrong in the .csv file, the command will not import the whole .csv file and might actually skip the whole import command altogether (need more testing). In the future, might need to fix this catastrophic bug to avoid this crashing if true. The list is non-exhaustive, I will add more examples of defensive coding when I remember it. Also, its currently missing test cases.