### PR TITLE
Improve find TelegramHandle command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEHANDLE;
 
 import java.util.function.Predicate;
 
@@ -20,7 +21,7 @@ public class FindCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names or Telegram handles "
         + "contain any of the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
         + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-        + "Example: " + COMMAND_WORD + " alice or " + COMMAND_WORD + " /h @alice";
+        + "Example: " + COMMAND_WORD + " alice or " + COMMAND_WORD + " " + PREFIX_TELEHANDLE + "@alice";
 
     // Use a generic Predicate<Person> to allow both name and handle filtering
     private final Predicate<Person> predicate;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEHANDLE;
 
 import java.util.Arrays;
 
@@ -26,13 +27,12 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        if (trimmedArgs.startsWith("/h")) {
-            if (trimmedArgs.length() <= 3) {
+        if (trimmedArgs.startsWith(PREFIX_TELEHANDLE.getPrefix())) {
+            String handleArgs = trimmedArgs.substring(PREFIX_TELEHANDLE.getPrefix().length()).trim();
+            if (handleArgs.isEmpty()) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
-
-            String handleArgs = trimmedArgs.substring(3).trim();
             String[] handleKeywords = handleArgs.split("\\s+");
             return new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays.asList(handleKeywords)));
         }
@@ -40,6 +40,4 @@ public class FindCommandParser implements Parser<FindCommand> {
         String[] nameKeywords = trimmedArgs.split("\\s+");
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
-
-
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -25,7 +25,7 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArgTelegramHandle_throwsParseException() {
-        assertParseFailure(parser, "/h     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "h/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindCommand.MESSAGE_USAGE));
     }
 
@@ -47,7 +47,7 @@ public class FindCommandParserTest {
             new FindCommand(new TelegramHandleContainsKeywordsPredicate(List.of("@amy123")));
 
         // Test with the correct input format
-        assertParseSuccess(parser, "/h @amy123", expectedFindCommand);
+        assertParseSuccess(parser, "h/@amy123", expectedFindCommand);
     }
 
     @Test
@@ -57,9 +57,9 @@ public class FindCommandParserTest {
             new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays.asList("@amy123", "@bob321")));
 
         // Test with the correct input format
-        assertParseSuccess(parser, "/h @amy123 @bob321", expectedFindCommand);
+        assertParseSuccess(parser, "h/@amy123 @bob321", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "/h \n @amy123 \n \t @bob321  \t", expectedFindCommand);
+        assertParseSuccess(parser, "h/ \n @amy123 \n \t @bob321  \t", expectedFindCommand);
     }
 }


### PR DESCRIPTION
Closes #143 

Update the required prefix for the find TelegramHandle command to the correct prefix "h/" instead of "/h"