### PR TITLE
Fix duplicate fields bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -79,6 +79,12 @@ public class AddCommand extends Command {
                     + "Please use a different telegram handle.");
         }
 
+        // Check for duplicate email
+        if (toAdd.getEmail().isPresent() && model.getAddressBook().hasEmail(toAdd.getEmail().get())) {
+            throw new CommandException("This email address already exists in the address book. "
+                    + "Please use a different email address.");
+        }
+
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -62,6 +62,11 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        // Check if the phone number is present and verify for duplicates
+        if (toAdd.getPhone().isPresent() && model.getAddressBook().hasPhoneNumber(toAdd.getPhone().get())) {
+            throw new CommandException("This phone number already exists in the address book.");
+        }
+
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -62,9 +62,16 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // Check if the phone number is present and verify for duplicates
+        // Check for duplicate phone numbers
         if (toAdd.getPhone().isPresent() && model.getAddressBook().hasPhoneNumber(toAdd.getPhone().get())) {
-            throw new CommandException("This phone number already exists in the address book.");
+            throw new CommandException("This phone number already exists in the address book. " +
+                    "Please use a different phone number.");
+        }
+
+        // Check for duplicate Telegram handle
+        if (toAdd.getTelegramHandle().isPresent() && model.getAddressBook().hasTelegramHandle(toAdd.getTelegramHandle().get())) {
+            throw new CommandException("This Telegram handle already exists in the address book. " +
+                    "Please use a different telegram handle.");
         }
 
         if (model.hasPerson(toAdd)) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -62,20 +62,21 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        if (model.hasPerson(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
         // Check for duplicate phone numbers
         if (toAdd.getPhone().isPresent() && model.getAddressBook().hasPhoneNumber(toAdd.getPhone().get())) {
-            throw new CommandException("This phone number already exists in the address book. " +
-                    "Please use a different phone number.");
+            throw new CommandException("This phone number already exists in the address book. "
+                    + "Please use a different phone number.");
         }
 
         // Check for duplicate Telegram handle
-        if (toAdd.getTelegramHandle().isPresent() && model.getAddressBook().hasTelegramHandle(toAdd.getTelegramHandle().get())) {
-            throw new CommandException("This Telegram handle already exists in the address book. " +
-                    "Please use a different telegram handle.");
-        }
-
-        if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        if (toAdd.getTelegramHandle().isPresent()
+                && model.getAddressBook().hasTelegramHandle(toAdd.getTelegramHandle().get())) {
+            throw new CommandException("This Telegram handle already exists in the address book. "
+                    + "Please use a different telegram handle.");
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,10 +6,7 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.person.TelegramHandle;
-import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.*;
 
 /**
  * Wraps all data at the address-book level
@@ -106,6 +103,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public boolean hasTelegramHandle(TelegramHandle telegramHandle) {
         return persons.hasTelegramHandle(telegramHandle); // persons is of type UniquePersonList
+    }
+
+    @Override
+    public boolean hasEmail(Email email) {
+        return persons.hasEmail(email); // persons is of type UniquePersonList
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.model.person.UniquePersonList;
 
 /**
@@ -94,6 +95,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedPerson);
 
         persons.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public boolean hasPhoneNumber(Phone phone) {
+        return persons.hasPhoneNumber(phone); // persons is of type UniquePersonList
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,6 +8,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramHandle;
 import seedu.address.model.person.UniquePersonList;
 
 /**
@@ -100,6 +101,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public boolean hasPhoneNumber(Phone phone) {
         return persons.hasPhoneNumber(phone); // persons is of type UniquePersonList
+    }
+
+    @Override
+    public boolean hasTelegramHandle(TelegramHandle telegramHandle) {
+        return persons.hasTelegramHandle(telegramHandle); // persons is of type UniquePersonList
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,7 +6,11 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramHandle;
+import seedu.address.model.person.UniquePersonList;
 
 /**
  * Wraps all data at the address-book level

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -3,11 +3,13 @@ package seedu.address.model;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramHandle;
 
 /**
  * Unmodifiable view of an address book
  */
 public interface ReadOnlyAddressBook {
+
 
     /**
      * Returns an unmodifiable view of the persons list.
@@ -22,5 +24,13 @@ public interface ReadOnlyAddressBook {
      * @return True if a person with the given phone number exists in the address book, false otherwise.
      */
     boolean hasPhoneNumber(Phone phone);
+
+    /**
+     * Checks if the address book contains a person with the given telegram handle.
+     *
+     * @param telegramHandle The telegram handle to check for.
+     * @return True if a person with the given telegram handle exists in the address book, false otherwise.
+     */
+    boolean hasTelegramHandle(TelegramHandle telegramHandle);
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.TelegramHandle;
@@ -32,5 +33,13 @@ public interface ReadOnlyAddressBook {
      * @return True if a person with the given telegram handle exists in the address book, false otherwise.
      */
     boolean hasTelegramHandle(TelegramHandle telegramHandle);
+
+    /**
+     * Checks if the address book contains a person with the given email.
+     *
+     * @param email The email to check for.
+     * @return True if a person with the given email exists in the address book, false otherwise.
+     */
+    boolean hasEmail(Email email);
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 
 /**
  * Unmodifiable view of an address book
@@ -13,5 +14,13 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+
+    /**
+     * Checks if the address book contains a person with the given phone number.
+     *
+     * @param phone The phone number to check for.
+     * @return True if a person with the given phone number exists in the address book, false otherwise.
+     */
+    boolean hasPhoneNumber(Phone phone);
 
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -97,7 +97,15 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                // && otherPerson.getName().equals(getName());
+                && otherPerson.getName().equals(getName())
+                && ((otherPerson.getPhone().isPresent()
+                            && getPhone().isPresent() && otherPerson.getPhone().get().equals(getPhone().get()))
+                            || (otherPerson.getEmail().isPresent() && getEmail().isPresent()
+                            && otherPerson.getEmail().get().equals(getEmail().get()))
+                            || (otherPerson.getTelegramHandle().isPresent() && getTelegramHandle().isPresent()
+                            && otherPerson.getTelegramHandle().get().equals(getTelegramHandle().get()))
+            );
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -97,7 +97,6 @@ public class Person {
         }
 
         return otherPerson != null
-                // && otherPerson.getName().equals(getName());
                 && otherPerson.getName().equals(getName())
                 && ((otherPerson.getPhone().isPresent()
                             && getPhone().isPresent() && otherPerson.getPhone().get().equals(getPhone().get()))

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -12,8 +12,8 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should start with an optional '+' followed by a country code, contain only numbers, "
-                    + "and be between 7 and 15 digits long.";
-    public static final String VALIDATION_REGEX = "\\+?\\d{7,15}";
+                    + "and be between 3 and 15 digits long.";
+    public static final String VALIDATION_REGEX = "\\+?\\d{3,15}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -13,7 +13,7 @@ public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should start with an optional '+' followed by a country code, contain only numbers, "
                     + "and be between 7 and 15 digits long.";
-    public static final String VALIDATION_REGEX = "\\+?\\d{3,15}";
+    public static final String VALIDATION_REGEX = "\\+?\\d{7,15}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -162,4 +162,19 @@ public class UniquePersonList implements Iterable<Person> {
         }
         return false;
     }
+
+    /**
+     * Checks if the list contains a person with the given Telegram handle.
+     *
+     * @param telegramHandle The Telegram handle to check for.
+     * @return True if a person with the given Telegram handle exists in the list, false otherwise.
+     */
+    public boolean hasTelegramHandle(TelegramHandle telegramHandle) {
+        for (Person person : internalList) {
+            if (person.getTelegramHandle().isPresent() && person.getTelegramHandle().get().equals(telegramHandle)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -177,4 +177,19 @@ public class UniquePersonList implements Iterable<Person> {
         }
         return false;
     }
+
+    /**
+     * Checks if the list contains a person with the given email.
+     *
+     * @param email The email to check for.
+     * @return True if a person with the given email exists in the list, false otherwise.
+     */
+    public boolean hasEmail(Email email) {
+        for (Person person : internalList) {
+            if (person.getEmail().isPresent() && person.getEmail().get().equals(email)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -147,4 +147,19 @@ public class UniquePersonList implements Iterable<Person> {
         }
         return true;
     }
+
+    /**
+     * Checks if the list contains a person with the given phone number.
+     *
+     * @param phone The phone number to check for.
+     * @return True if a person with the given phone number exists in the list, false otherwise.
+     */
+    public boolean hasPhoneNumber(Phone phone) {
+        for (Person person : internalList) {
+            if (person.getPhone().isPresent() && person.getPhone().get().equals(phone)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -28,7 +28,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "1234567";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TELEHANDLE = "@rachel123";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.TelegramHandle;
@@ -114,6 +115,12 @@ public class AddressBookTest {
         @Override
         public boolean hasPhoneNumber(Phone phone) {
             // This is a stub method for testing purposes, returning false by default.
+            return true;
+        }
+
+        @Override
+        public boolean hasEmail(Email email) {
+            // This is a stub method for testing purposes, returning fa
             return true;
         }
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -108,19 +108,19 @@ public class AddressBookTest {
 
         @Override
         public boolean hasTelegramHandle(TelegramHandle telegramHandle) {
-            // This is a stub method for testing purposes, returning fa
+            // This is a stub method for testing purposes, returning true by default
             return true;
         }
 
         @Override
         public boolean hasPhoneNumber(Phone phone) {
-            // This is a stub method for testing purposes, returning false by default.
+            // This is a stub method for testing purposes, returning true by default
             return true;
         }
 
         @Override
         public boolean hasEmail(Email email) {
-            // This is a stub method for testing purposes, returning fa
+            // This is a stub method for testing purposes, returning true by default
             return true;
         }
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramHandle;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
 
@@ -101,6 +103,18 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public boolean hasTelegramHandle(TelegramHandle telegramHandle) {
+            // This is a stub method for testing purposes, returning fa
+            return true;
+        }
+
+        @Override
+        public boolean hasPhoneNumber(Phone phone) {
+            // This is a stub method for testing purposes, returning false by default.
+            return true;
         }
     }
 

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -69,8 +69,8 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("1234567", "alice@email.com"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("1234567")
                 .withEmail("alice@email.com").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -35,7 +35,7 @@ public class PersonTest {
         // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTelegramHandle(VALID_TELEHANDLE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSamePerson(editedAlice));
+        assertFalse(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -32,7 +32,7 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
+        // same name, all other attributes different -> returns false
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTelegramHandle(VALID_TELEHANDLE_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.isSamePerson(editedAlice));


### PR DESCRIPTION
Prevents duplicate phone numbers, emails or telegram handles but allow duplicate names as long as none of these fields are identical as two people can have the same name in real life.
closes #163 
closes #165 
closes #166 
closes #167 
closes #181