### PR TITLE
Fix error message typos

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -23,15 +23,15 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. \n"
             + "Parameters: "
-            + PREFIX_CONTACTTYPE + "CONTACT TYPE "
             + PREFIX_NAME + "NAME "
-            + "[" + PREFIX_TELEHANDLE + "TELEGRAMHANDLE] "
-            + PREFIX_MOD + "MODULE NAME "
-            + PREFIX_REMARK + "REMARK "
+            + PREFIX_CONTACTTYPE + "CONTACT TYPE "
+            + "[" + PREFIX_TELEHANDLE + "TELEGRAM HANDLE] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_MOD + "MODULE NAME] "
+            + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_CONTACTTYPE + "work "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -48,13 +48,13 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_TELEHANDLE + "TELEHANDLE] "
+            + "[" + PREFIX_TELEHANDLE + "TELEGRAM HANDLE] "
             + "[" + PREFIX_CONTACTTYPE + "CONTACT TYPE] "
             + "[" + PREFIX_MOD + "MODULE NAME] "
             + "[" + PREFIX_REMARK + "REMARK]"
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_TELEHANDLE + "@johndoe"
+            + PREFIX_TELEHANDLE + "@johndoe "
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";


### PR DESCRIPTION
Fixes #220 (add command error message missing square brackets)
Fixes #197 (edit command error message example missing space)
Fixes #195 (add command error message missing square brackets)